### PR TITLE
Fix data race in test

### DIFF
--- a/trylock_test.go
+++ b/trylock_test.go
@@ -164,7 +164,7 @@ func TestMutexLockBroadcast(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	if done != 3 {
+	if atomic.LoadInt32(&done) != 3 {
 		t.Fatal("Broadcast is failed")
 	}
 }


### PR DESCRIPTION
First of all, thanks for a nice library!

I found a data race when I ran

```
go test -v -race
```

This pull request fixes the data race.