### PR TITLE
add some benchmarks. concurrency test case was failed.

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,132 @@
+package trylock
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func BenchmarkStdLock(b *testing.B) {
+	mux := sync.Mutex{}
+	b.Run("goroutine-1", func(_b *testing.B) {
+		_b.ReportAllocs()
+		for i := 0; i < _b.N; i++ {
+			mux.Lock()
+			mux.Unlock()
+		}
+	})
+
+	b.Run("goroutine-N", func(_b *testing.B) {
+		var countor = 0
+		var wg sync.WaitGroup
+		for i := 0; i < _b.N; i++ {
+			_b.ReportAllocs()
+			wg.Add(1)
+			go func() {
+				mux.Lock()
+				countor++
+				mux.Unlock()
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+func BenchmarkLock(b *testing.B) {
+	mux := New()
+	b.Run("goroutine-1", func(_b *testing.B) {
+		_b.ReportAllocs()
+		for i := 0; i < _b.N; i++ {
+			mux.Lock()
+			mux.Unlock()
+		}
+	})
+
+	b.Run("goroutine-N", func(_b *testing.B) {
+		var countor = 0
+		var wg sync.WaitGroup
+		for i := 0; i < _b.N; i++ {
+			_b.ReportAllocs()
+			wg.Add(1)
+			go func() {
+				mux.Lock()
+				countor++
+				mux.Unlock()
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		if countor != _b.N {
+			b.Fatalf("countor(%d) != _b.N(%d)", countor, _b.N)
+		}
+	})
+}
+
+func BenchmarkTryLock(b *testing.B) {
+	mux := New()
+	b.Run("goroutine-1", func(_b *testing.B) {
+		_b.ReportAllocs()
+		for i := 0; i < _b.N; i++ {
+			if !mux.TryLock(nil) {
+				_b.FailNow()
+			}
+			mux.Unlock()
+		}
+	})
+
+	b.Run("goroutine-N", func(_b *testing.B) {
+		var countor = 0
+		var wg sync.WaitGroup
+		for i := 0; i < _b.N; i++ {
+			_b.ReportAllocs()
+			wg.Add(1)
+			go func() {
+				if !mux.TryLock(nil) {
+					_b.FailNow()
+				}
+				countor++
+				mux.Unlock()
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		if countor != _b.N {
+			b.Fatalf("countor(%d) != _b.N(%d)", countor, _b.N)
+		}
+	})
+}
+
+func BenchmarkTryLockTimeout(b *testing.B) {
+	mux := New()
+	b.Run("goroutine-1", func(_b *testing.B) {
+		_b.ReportAllocs()
+		for i := 0; i < _b.N; i++ {
+			if !mux.TryLockTimeout(1 * time.Millisecond) {
+				_b.FailNow()
+			}
+			mux.Unlock()
+		}
+	})
+
+	b.Run("goroutine-N", func(_b *testing.B) {
+		var countor = 0
+		var wg sync.WaitGroup
+		for i := 0; i < _b.N; i++ {
+			_b.ReportAllocs()
+			wg.Add(1)
+			go func() {
+				if !mux.TryLockTimeout(1000 * time.Millisecond) {
+					_b.FailNow()
+				}
+				countor++
+				mux.Unlock()
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		if countor != _b.N {
+			b.Fatalf("countor(%d) != _b.N(%d)", countor, _b.N)
+		}
+	})
+}


### PR DESCRIPTION
I run `go test -bench=.` many times, then I got some `deadlock` in concurrency test cases.


### Lock
```
goos: linux
goarch: amd64
pkg: github.com/subchen/go-trylock/v2
BenchmarkStdLock/goroutine-1-8         	129828927	         9.04 ns/op	       0 B/op	       0 allocs/op
BenchmarkStdLock/goroutine-N-8         	 4820733	       248 ns/op	       0 B/op	       0 allocs/op
BenchmarkLock/goroutine-1-8            	15406830	        83.9 ns/op	      96 B/op	       1 allocs/op
BenchmarkLock/goroutine-N-8            	fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
testing.(*B).run1(0xc000126380, 0xc000126380)
	/usr/lib/go/src/testing/benchmark.go:233 +0x9e
testing.(*B).Run(0xc000126000, 0x54a08e, 0xd, 0x5525d8, 0x4bb900)
	/usr/lib/go/src/testing/benchmark.go:651 +0x341
testing.runBenchmarks.func1(0xc000126000)
	/usr/lib/go/src/testing/benchmark.go:533 +0x78
testing.(*B).runN(0xc000126000, 0x1)
	/usr/lib/go/src/testing/benchmark.go:191 +0xe8
testing.runBenchmarks(0x54e716, 0x20, 0xc00000c120, 0x6454c0, 0x4, 0x4, 0xc000072e01)
	/usr/lib/go/src/testing/benchmark.go:539 +0x390
testing.(*M).Run(0xc000110000, 0x0)
	/usr/lib/go/src/testing/testing.go:1205 +0x42d
main.main()
	_testmain.go:70 +0x135

goroutine 5830919 [chan receive]:
testing.(*B).doBench(0xc000126540, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/lib/go/src/testing/benchmark.go:277 +0x73
testing.(*benchContext).processBench(0xc00000c140, 0xc000126540)
	/usr/lib/go/src/testing/benchmark.go:568 +0x207
testing.(*B).run(0xc000126540)
	/usr/lib/go/src/testing/benchmark.go:268 +0x63
testing.(*B).Run(0xc000126380, 0x549b96, 0xb, 0xc00000c0a0, 0x4bb900)
	/usr/lib/go/src/testing/benchmark.go:652 +0x3fd
github.com/subchen/go-trylock/v2.BenchmarkLock(0xc000126380)
	/home/cupen/workbench/repos/go-trylock/benchmarks_test.go:46 +0x166
testing.(*B).runN(0xc000126380, 0x1)
	/usr/lib/go/src/testing/benchmark.go:191 +0xe8
testing.(*B).run1.func1(0xc000126380)
	/usr/lib/go/src/testing/benchmark.go:231 +0x57
created by testing.(*B).run1
	/usr/lib/go/src/testing/benchmark.go:224 +0x7d

goroutine 5501051 [semacquire]:
sync.runtime_Semacquire(0xc000184038)
	/usr/lib/go/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc000184030)
	/usr/lib/go/src/sync/waitgroup.go:130 +0x64
github.com/subchen/go-trylock/v2.BenchmarkLock.func2(0xc000126540)
	/home/cupen/workbench/repos/go-trylock/benchmarks_test.go:59 +0x109
testing.(*B).runN(0xc000126540, 0x488d36)
	/usr/lib/go/src/testing/benchmark.go:191 +0xe8
testing.(*B).launch(0xc000126540)
	/usr/lib/go/src/testing/benchmark.go:321 +0xea
created by testing.(*B).doBench
	/usr/lib/go/src/testing/benchmark.go:276 +0x55

goroutine 11595769 [select]:
github.com/subchen/go-trylock/v2.(*trylocker).TryLock(0xc00000c020, 0x574380, 0xc00001a108, 0x552918)
	/home/cupen/workbench/repos/go-trylock/trylock.go:91 +0x111
github.com/subchen/go-trylock/v2.(*trylocker).Lock(0xc00000c020)
	/home/cupen/workbench/repos/go-trylock/trylock.go:135 +0x43
github.com/subchen/go-trylock/v2.BenchmarkLock.func2.1(0x575020, 0xc00000c020, 0xc000184020, 0xc000184030)
	/home/cupen/workbench/repos/go-trylock/benchmarks_test.go:53 +0x31
created by github.com/subchen/go-trylock/v2.BenchmarkLock.func2
	/home/cupen/workbench/repos/go-trylock/benchmarks_test.go:52 +0xe1
exit status 2
FAIL	github.com/subchen/go-trylock/v2	10.836s
```

### TryLock
```
goos: linux
goarch: amd64
pkg: github.com/subchen/go-trylock/v2
BenchmarkStdLock/goroutine-1-8         	129199300	         9.01 ns/op	       0 B/op	       0 allocs/op
BenchmarkStdLock/goroutine-N-8         	 5359784	       224 ns/op	       0 B/op	       0 allocs/op
BenchmarkLock/goroutine-1-8            	15884559	        94.5 ns/op	      96 B/op	       1 allocs/op
BenchmarkLock/goroutine-N-8            	 4319998	       269 ns/op	      98 B/op	       1 allocs/op
BenchmarkTryLock/goroutine-1-8         	14686035	        89.6 ns/op	      96 B/op	       1 allocs/op
BenchmarkTryLock/goroutine-N-8         	fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
testing.(*B).run1(0xc0001ae1c0, 0xc0001ae1c0)
	/usr/lib/go/src/testing/benchmark.go:233 +0x9e
testing.(*B).Run(0xc0001ae000, 0x54a93a, 0x10, 0x552608, 0x4bb900)
	/usr/lib/go/src/testing/benchmark.go:651 +0x341
testing.runBenchmarks.func1(0xc0001ae000)
	/usr/lib/go/src/testing/benchmark.go:533 +0x78
testing.(*B).runN(0xc0001ae000, 0x1)
	/usr/lib/go/src/testing/benchmark.go:191 +0xe8
testing.runBenchmarks(0x54e716, 0x20, 0xc00018c0a0, 0x6454c0, 0x4, 0x4, 0xc000072e01)
	/usr/lib/go/src/testing/benchmark.go:539 +0x390
testing.(*M).Run(0xc000090000, 0x0)
	/usr/lib/go/src/testing/testing.go:1205 +0x42d
main.main()
	_testmain.go:70 +0x135

goroutine 11178443 [chan receive]:
testing.(*B).doBench(0xc0001ae540, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/lib/go/src/testing/benchmark.go:277 +0x73
testing.(*benchContext).processBench(0xc00018c0c0, 0xc0001ae540)
	/usr/lib/go/src/testing/benchmark.go:568 +0x207
testing.(*B).run(0xc0001ae540)
	/usr/lib/go/src/testing/benchmark.go:268 +0x63
testing.(*B).Run(0xc0001ae1c0, 0x549b96, 0xb, 0xc00000c0a0, 0x4bb900)
	/usr/lib/go/src/testing/benchmark.go:652 +0x3fd
github.com/subchen/go-trylock/v2.BenchmarkTryLock(0xc0001ae1c0)
	/home/cupen/workbench/repos/go-trylock/benchmarks_test.go:78 +0x166
testing.(*B).runN(0xc0001ae1c0, 0x1)
	/usr/lib/go/src/testing/benchmark.go:191 +0xe8
testing.(*B).run1.func1(0xc0001ae1c0)
	/usr/lib/go/src/testing/benchmark.go:231 +0x57
created by testing.(*B).run1
	/usr/lib/go/src/testing/benchmark.go:224 +0x7d

goroutine 11700080 [semacquire]:
sync.runtime_Semacquire(0xc00001a198)
	/usr/lib/go/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc00001a190)
	/usr/lib/go/src/sync/waitgroup.go:130 +0x64
github.com/subchen/go-trylock/v2.BenchmarkTryLock.func2(0xc0001ae540)
	/home/cupen/workbench/repos/go-trylock/benchmarks_test.go:93 +0x11a
testing.(*B).runN(0xc0001ae540, 0x64)
	/usr/lib/go/src/testing/benchmark.go:191 +0xe8
testing.(*B).launch(0xc0001ae540)
	/usr/lib/go/src/testing/benchmark.go:321 +0xea
created by testing.(*B).doBench
	/usr/lib/go/src/testing/benchmark.go:276 +0x55
exit status 2
FAIL	github.com/subchen/go-trylock/v2	9.281s
```
